### PR TITLE
Always use workers under the hood to execute commands.

### DIFF
--- a/scripts/smart_dispatch.py
+++ b/scripts/smart_dispatch.py
@@ -36,10 +36,10 @@ def main():
             jobname = args.commandsFile.name
             commands = smartdispatch.get_commands_from_file(args.commandsFile)
         else:
-            # Command that needs to be parsed and unfolded.
-            command = " ".join(args.commandAndOptions)
-            jobname = smartdispatch.generate_name_from_command(command, max_length=235)
-            commands = smartdispatch.unfold_command(command)
+            # Commands that needs to be parsed and unfolded.
+            arguments = map(smartdispatch.unfold_argument, args.commandAndOptions)
+            jobname = smartdispatch.generate_name_from_arguments(arguments)
+            commands = smartdispatch.get_commands_from_arguments(arguments)
 
         commands = smartdispatch.replace_uid_tag(commands)
         nb_commands = len(commands)  # For print at the end
@@ -51,20 +51,19 @@ def main():
     else:
         raise ValueError("Unknown subcommand!")
 
-    # Pool of workers
-    if args.pool is not None:
-        command_manager = CommandManager(os.path.join(path_job_commands, "commands.txt"))
+    command_manager = CommandManager(os.path.join(path_job_commands, "commands.txt"))
 
-        # If resume mode, reset running jobs
-        if args.mode == "launch":
-            command_manager.set_commands_to_run(commands)
-        else:
-            command_manager.reset_running_commands()
-            nb_commands = command_manager.get_nb_commands_to_run()
+    # If resume mode, reset running jobs
+    if args.mode == "launch":
+        command_manager.set_commands_to_run(commands)
+    elif args.mode == "resume":
+        command_manager.reset_running_commands()
+        nb_commands = command_manager.get_nb_commands_to_run()
 
-        worker_command = 'smart_worker.py "{0}" "{1}"'.format(command_manager._commands_filename, path_job_logs)
-        # Replace commands with `args.pool` workers
-        commands = [worker_command] * args.pool
+    # Use a pool of workers to execute commands
+    nb_workers = min(command_manager.count_commands(), args.pool)
+    worker_command = 'smart_worker.py "{0}" "{1}"'.format(command_manager._commands_filename, path_job_logs)
+    commands = [worker_command] * nb_workers  # Replace commands with `nb_workers` workers
 
     # Add redirect for output and error logs
     for i, command in enumerate(commands):
@@ -118,7 +117,7 @@ def parse_arguments():
     parser.add_argument('-l', '--modules', type=str, required=False, help='List of additional modules to load.', nargs='+')
     parser.add_argument('-x', '--doNotLaunch', action='store_true', help='Creates the QSUB files without launching them.')
 
-    parser.add_argument('-p', '--pool', type=int, help="Number of workers that will be consuming commands.")
+    parser.add_argument('-p', '--pool', type=int, help="Number of workers that will be consuming commands.", default=np.iinfo('int').max)
     subparsers = parser.add_subparsers(dest="mode")
 
     launch_parser = subparsers.add_parser('launch', help="Launch jobs.")
@@ -135,10 +134,7 @@ def parse_arguments():
             parser.error("You need to specify a command to launch.")
         if args.queueName not in AVAILABLE_QUEUES and ((args.coresPerNode is None and args.gpusPerNode is None) or args.walltime is None):
             parser.error("Unknown queue, --coresPerNode/--gpusPerNode and --walltime must be set.")
-    else:
-        if args.pool is None:
-            resume_parser.error("The resume feature only works with the --pool argument.")
-
+    
     return args
 
 

--- a/scripts/smart_dispatch.py
+++ b/scripts/smart_dispatch.py
@@ -36,10 +36,10 @@ def main():
             jobname = args.commandsFile.name
             commands = smartdispatch.get_commands_from_file(args.commandsFile)
         else:
-            # Commands that needs to be parsed and unfolded.
-            arguments = map(smartdispatch.unfold_argument, args.commandAndOptions)
-            jobname = smartdispatch.generate_name_from_arguments(arguments)
-            commands = smartdispatch.get_commands_from_arguments(arguments)
+            # Command that needs to be parsed and unfolded.
+            command = " ".join(args.commandAndOptions)
+            jobname = smartdispatch.generate_name_from_command(command, max_length=235)
+            commands = smartdispatch.unfold_command(command)
 
         commands = smartdispatch.replace_uid_tag(commands)
         nb_commands = len(commands)  # For print at the end
@@ -61,7 +61,7 @@ def main():
         nb_commands = command_manager.get_nb_commands_to_run()
 
     # Use a pool of workers to execute commands
-    nb_workers = min(command_manager.count_commands(), args.pool)
+    nb_workers = min(command_manager.get_nb_commands_to_run(), args.pool)
     worker_command = 'smart_worker.py "{0}" "{1}"'.format(command_manager._commands_filename, path_job_logs)
     commands = [worker_command] * nb_workers  # Replace commands with `nb_workers` workers
 
@@ -134,7 +134,7 @@ def parse_arguments():
             parser.error("You need to specify a command to launch.")
         if args.queueName not in AVAILABLE_QUEUES and ((args.coresPerNode is None and args.gpusPerNode is None) or args.walltime is None):
             parser.error("Unknown queue, --coresPerNode/--gpusPerNode and --walltime must be set.")
-    
+
     return args
 
 

--- a/smartdispatch/command_manager.py
+++ b/smartdispatch/command_manager.py
@@ -57,7 +57,3 @@ class CommandManager(object):
                         commands += commands_file.readlines()
                         commands_file.seek(0, os.SEEK_SET)
                         commands_file.writelines(commands)
-
-    def count_commands(self):
-        commands = open(self._commands_filename).readlines()
-        return len(commands)

--- a/smartdispatch/command_manager.py
+++ b/smartdispatch/command_manager.py
@@ -57,3 +57,7 @@ class CommandManager(object):
                         commands += commands_file.readlines()
                         commands_file.seek(0, os.SEEK_SET)
                         commands_file.writelines(commands)
+
+    def count_commands(self):
+        commands = open(self._commands_filename).readlines()
+        return len(commands)

--- a/smartdispatch/tests/test_command_manager.py
+++ b/smartdispatch/tests/test_command_manager.py
@@ -58,7 +58,7 @@ class CommandFilesTests(unittest.TestCase):
         assert_true(not os.path.isfile(self.command_manager._finished_commands_filename))
 
     def test_get_nb_commands_to_run(self):
-        assert_equal(self.command_manager.get_nb_commands_to_run(), 3)
+        assert_equal(self.command_manager.get_nb_commands_to_run(), self.nb_commands)
 
     def test_set_running_command_as_finished(self):
         # SetUp
@@ -92,13 +92,3 @@ class CommandFilesTests(unittest.TestCase):
             assert_equal(running_commands_file.read(), "")
 
         assert_true(not os.path.isfile(self.command_manager._finished_commands_filename))
-
-    def test_count_commands(self):
-        # SetUp
-        commands = ["4", "5", "6", "7"]
-
-        # The function to test
-        assert_equal(self.command_manager.count_commands(), self.nb_commands)
-
-        self.command_manager.set_commands_to_run(commands)
-        assert_equal(self.command_manager.count_commands(), len(commands) + self.nb_commands)

--- a/smartdispatch/tests/test_command_manager.py
+++ b/smartdispatch/tests/test_command_manager.py
@@ -11,11 +11,13 @@ class CommandFilesTests(unittest.TestCase):
 
     def setUp(self):
         self._base_dir = tmp.mkdtemp()
+        self.nb_commands = 3
+
         self.command1 = "1\n"
         self.command2 = "2\n"
         self.command3 = "3\n"
 
-        command_filename = os.path.join(self._base_dir, "commant.txt")
+        command_filename = os.path.join(self._base_dir, "command.txt")
 
         with open(command_filename, "w+") as commands_file:
             commands_file.write(self.command1 + self.command2 + self.command3)
@@ -90,3 +92,13 @@ class CommandFilesTests(unittest.TestCase):
             assert_equal(running_commands_file.read(), "")
 
         assert_true(not os.path.isfile(self.command_manager._finished_commands_filename))
+
+    def test_count_commands(self):
+        # SetUp
+        commands = ["4", "5", "6", "7"]
+
+        # The function to test
+        assert_equal(self.command_manager.count_commands(), self.nb_commands)
+
+        self.command_manager.set_commands_to_run(commands)
+        assert_equal(self.command_manager.count_commands(), len(commands) + self.nb_commands)


### PR DESCRIPTION
By default, the number of workers is set to the number of commands to be executed.

Using `-p`, one can set the number of workers to use.