### PR TITLE
FIX: Change directory before executing a command.

### DIFF
--- a/scripts/smart_dispatch.py
+++ b/scripts/smart_dispatch.py
@@ -65,7 +65,7 @@ def main():
     # Add redirect for output and error logs
     for i, command in enumerate(commands):
         # Change directory before executing command
-        commands[i] = 'cd {cwd}; '.format(cwd=os.getcwd()) + commands[i]
+        commands[i] = 'cd "{cwd}"; '.format(cwd=os.getcwd()) + commands[i]
         # Log command's output and command's error
         log_filename = os.path.join(path_job_logs, smartdispatch.generate_name_from_command(command, max_length_arg=30))
         commands[i] += ' 1>> "{output_log}"'.format(output_log=log_filename + ".o")


### PR DESCRIPTION
Right now, every command is run in user's `$HOME` folder, which is not what we expect from `smart_dispatch.py`é
Also, changing directory before executing a command will allow running scripts/programs that are in the current directory without including them in `$PATH`.

@mgermain, @laulysta needs this as soon as possible.
