### PR TITLE
Resume only pending commands

### DIFF
--- a/scripts/smart_dispatch.py
+++ b/scripts/smart_dispatch.py
@@ -77,7 +77,7 @@ def main():
             if not utils.yes_no_prompt("Do you want to continue?", 'n'):
                 exit()
 
-        if not args.only_pending:
+        if not args.onlyPending:
             command_manager.reset_running_commands()
 
         nb_commands = command_manager.get_nb_commands_to_run()
@@ -144,7 +144,7 @@ def parse_arguments():
     launch_parser.add_argument("commandAndOptions", help="Options for the commands.", nargs=argparse.REMAINDER)
 
     resume_parser = subparsers.add_parser('resume', help="Resume jobs from batch UID.")
-    resume_parser.add_argument('--only_pending', action='store_true', help='Resume only pending commands.')
+    resume_parser.add_argument('--onlyPending', action='store_true', help='Resume only pending commands.')
     resume_parser.add_argument("batch_uid", help="Batch UID of the jobs to resume.")
 
     args = parser.parse_args()

--- a/scripts/smart_dispatch.py
+++ b/scripts/smart_dispatch.py
@@ -77,7 +77,9 @@ def main():
             if not utils.yes_no_prompt("Do you want to continue?", 'n'):
                 exit()
 
-        command_manager.reset_running_commands()
+        if not args.only_pending:
+            command_manager.reset_running_commands()
+
         nb_commands = command_manager.get_nb_commands_to_run()
 
     # If no pool size is specified the number of commands is taken
@@ -142,6 +144,7 @@ def parse_arguments():
     launch_parser.add_argument("commandAndOptions", help="Options for the commands.", nargs=argparse.REMAINDER)
 
     resume_parser = subparsers.add_parser('resume', help="Resume jobs from batch UID.")
+    resume_parser.add_argument('--only_pending', action='store_true', help='Resume only pending commands.')
     resume_parser.add_argument("batch_uid", help="Batch UID of the jobs to resume.")
 
     args = parser.parse_args()

--- a/tests/test_smart_dispatch.py
+++ b/tests/test_smart_dispatch.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import tempfile
 import shutil
+from os.path import join as pjoin
 
 from subprocess import call
 
@@ -15,13 +16,14 @@ class TestSmartdispatcher(unittest.TestCase):
         self.logs_dir = os.path.join(self.testing_dir, 'SMART_DISPATCH_LOGS')
 
         base_command = 'smart_dispatch.py --pool 10 -C 42 -q test -t 5:00 -x {0}'
-        self.launch_command = base_command.format('launch echo "1 2 3 4" "6 7 8" "9 0"')
+        self.launch_command = base_command.format('launch echo "[1 2 3 4]" "[6 7 8]" "[9 0]"')
         self.resume_command = base_command.format('resume {0}')
 
         self._cwd = os.getcwd()
         os.chdir(self.testing_dir)
 
     def tearDown(self):
+        print "Tear down"
         os.chdir(self._cwd)
         shutil.rmtree(self.testing_dir)
 
@@ -39,10 +41,49 @@ class TestSmartdispatcher(unittest.TestCase):
         call(self.launch_command, shell=True)
         batch_uid = os.listdir(self.logs_dir)[0]
 
-        # Actual test
+        # Simulate that some commands are in the running state.
+        path_job_commands = os.path.join(self.logs_dir, batch_uid, "commands")
+        pending_commands_file = pjoin(path_job_commands, "commands.txt")
+        running_commands_file = pjoin(path_job_commands, "running_commands.txt")
+        commands = open(pending_commands_file).read().strip().split("\n")
+        with open(running_commands_file, 'w') as running_commands:
+            running_commands.write("\n".join(commands[::2]) + "\n")
+        with open(pending_commands_file, 'w') as pending_commands:
+            pending_commands.write("\n".join(commands[1::2]) + "\n")
+
+        # Actual test (should move running commands back to pending).
         exit_status = call(self.resume_command.format(batch_uid), shell=True)
 
         # Test validation
         assert_equal(exit_status, 0)
         assert_true(os.path.isdir(self.logs_dir))
         assert_equal(len(os.listdir(self.logs_dir)), 1)
+        assert_equal(len(open(running_commands_file).readlines()), 0)
+        assert_equal(len(open(pending_commands_file).readlines()), len(commands))
+
+    def test_main_resume_only_pending(self):
+        # SetUp
+        call(self.launch_command, shell=True)
+        batch_uid = os.listdir(self.logs_dir)[0]
+
+        # Simulate that some commands are in the running state.
+        path_job_commands = os.path.join(self.logs_dir, batch_uid, "commands")
+        pending_commands_file = pjoin(path_job_commands, "commands.txt")
+        running_commands_file = pjoin(path_job_commands, "running_commands.txt")
+        commands = open(pending_commands_file).read().strip().split("\n")
+        with open(running_commands_file, 'w') as running_commands:
+            running_commands.write("\n".join(commands[::2]) + "\n")
+        with open(pending_commands_file, 'w') as pending_commands:
+            pending_commands.write("\n".join(commands[1::2]) + "\n")
+
+        # Actual test (should NOT move running commands back to pending).
+        command_line = self.resume_command.format(batch_uid)
+        command_line += " --onlyPending"
+        exit_status = call(command_line, shell=True)
+
+        # Test validation
+        assert_equal(exit_status, 0)
+        assert_true(os.path.isdir(self.logs_dir))
+        assert_equal(len(os.listdir(self.logs_dir)), 1)
+        assert_equal(len(open(running_commands_file).readlines()), len(commands[::2]))
+        assert_equal(len(open(pending_commands_file).readlines()), len(commands[1::2]))


### PR DESCRIPTION
I added an option to `smart_dispatch` so we can resume only commands that are pending.

I find it useful in the following context:
Let suppose half of my jobs failed because of easy-to-fix bugs. Then, after I fixed it, I want to relaunch the failed commands (but some commands are already running). Now, I can easily do a `echo failed_commands.txt >> commands.txt` followed by a `smart_dispatch resume JOBIB --onlyPending`.

Without the `--onlyPending` option, the running commands (i.e. found in `running_commands.txt`) would be put along the others commands in `commands.txt` and relaunched!