### PR TITLE
Support both path and Batch UID when resuming jobs.

### DIFF
--- a/scripts/smart_dispatch.py
+++ b/scripts/smart_dispatch.py
@@ -20,7 +20,6 @@ from smartdispatch import utils
 import logging
 import smartdispatch
 
-
 LOGS_FOLDERNAME = "SMART_DISPATCH_LOGS"
 CLUSTER_NAME = utils.detect_cluster()
 AVAILABLE_QUEUES = get_available_queues(CLUSTER_NAME)
@@ -32,6 +31,7 @@ def main():
     logging.root.setLevel(logging.INFO)
 
     args = parse_arguments()
+    path_smartdispatch_logs = pjoin(os.getcwd(), LOGS_FOLDERNAME)
 
     # Check if RESUME or LAUNCH mode
     if args.mode == "launch":
@@ -48,12 +48,19 @@ def main():
         commands = smartdispatch.replace_uid_tag(commands)
         nb_commands = len(commands)  # For print at the end
 
-        path_job, path_job_logs, path_job_commands = create_job_folders(jobname)
     elif args.mode == "resume":
         jobname = args.batch_uid
-        path_job, path_job_logs, path_job_commands = get_job_folders(args.batch_uid)
+        if os.path.isdir(jobname):
+            # We assume `jobname` is `path_job` repo, we extract the real `jobname`.
+            jobname = os.path.basename(os.path.abspath(jobname))
+
+        if not os.path.isdir(pjoin(path_smartdispatch_logs, jobname)):
+            raise LookupError("Batch UID ({0}) does not exist! Cannot resume.".format(jobname))
     else:
         raise ValueError("Unknown subcommand!")
+
+    job_folders_paths = smartdispatch.get_job_folders(path_smartdispatch_logs, jobname)
+    path_job, path_job_logs, path_job_commands = job_folders_paths
 
     # Keep a log of the command line in the job folder.
     command_line = " ".join(sys.argv)
@@ -163,50 +170,6 @@ def parse_arguments():
             parser.error("Unknown queue, --coresPerNode/--gpusPerNode and --walltime must be set.")
 
     return args
-
-
-def _gen_job_paths(jobname):
-    path_smartdispatch_logs = pjoin(os.getcwd(), LOGS_FOLDERNAME)
-    path_job = pjoin(path_smartdispatch_logs, jobname)
-    path_job_logs = pjoin(path_job, 'logs')
-    path_job_commands = pjoin(path_job, 'commands')
-
-    return path_job, path_job_logs, path_job_commands
-
-
-def get_job_folders(jobname):
-    if os.path.isdir(jobname):
-        # We assume `jobname` is `path_job` repo, we extract the real `jobname`.
-        jobname = os.path.basename(os.path.abspath(jobname))
-
-    path_job, path_job_logs, path_job_commands = _gen_job_paths(jobname)
-
-    if not os.path.exists(path_job_commands):
-        raise LookupError("Batch UID ({0}) does not exist! Cannot resume.".format(jobname))
-
-    if not os.path.exists(path_job_logs):
-        os.makedirs(path_job_logs)
-    if not os.path.exists(pjoin(path_job_logs, "worker")):
-        os.makedirs(pjoin(path_job_logs, "worker"))
-    if not os.path.exists(pjoin(path_job_logs, "job")):
-        os.makedirs(pjoin(path_job_logs, "job"))
-
-    return path_job, path_job_logs, path_job_commands
-
-
-def create_job_folders(jobname):
-    """Creates the folders where the logs, commands and QSUB files will be saved."""
-    path_job, path_job_logs, path_job_commands = _gen_job_paths(jobname)
-
-    if not os.path.exists(path_job_commands):
-        os.makedirs(path_job_commands)
-
-    if not os.path.exists(path_job_logs):
-        os.makedirs(path_job_logs)
-        os.makedirs(pjoin(path_job_logs, "worker"))
-        os.makedirs(pjoin(path_job_logs, "job"))
-
-    return path_job, path_job_logs, path_job_commands
 
 
 if __name__ == "__main__":

--- a/scripts/smart_dispatch.py
+++ b/scripts/smart_dispatch.py
@@ -175,6 +175,10 @@ def _gen_job_paths(jobname):
 
 
 def get_job_folders(jobname):
+    if os.path.isdir(jobname):
+        # We assume `jobname` is `path_job` repo, we extract the real `jobname`.
+        jobname = os.path.basename(os.path.abspath(jobname))
+
     path_job, path_job_logs, path_job_commands = _gen_job_paths(jobname)
 
     if not os.path.exists(path_job_commands):

--- a/smartdispatch/smartdispatch.py
+++ b/smartdispatch/smartdispatch.py
@@ -110,16 +110,34 @@ def get_available_queues(cluster_name=utils.detect_cluster()):
         return {}
 
     smartdispatch_dir, _ = os.path.split(smartdispatch.__file__)
-    config_dir = os.path.join(smartdispatch_dir, 'config')
+    config_dir = pjoin(smartdispatch_dir, 'config')
 
     config_filename = cluster_name + ".json"
-    config_filepath = os.path.join(config_dir, config_filename)
+    config_filepath = pjoin(config_dir, config_filename)
 
     if not os.path.isfile(config_filepath):
         return {}  # Unknown cluster
 
     queues_infos = utils.load_dict_from_json_file(config_filepath)
     return queues_infos
+
+
+def get_job_folders(path, jobname, create_if_needed=False):
+    """ Get all folder paths for a specific job (creating them if needed). """
+    path_job = pjoin(path, jobname)
+    path_job_logs = pjoin(path_job, 'logs')
+    path_job_commands = pjoin(path_job, 'commands')
+
+    if not os.path.isdir(path_job_commands):
+        os.makedirs(path_job_commands)
+    if not os.path.isdir(path_job_logs):
+        os.makedirs(path_job_logs)
+    if not os.path.isdir(pjoin(path_job_logs, "worker")):
+        os.makedirs(pjoin(path_job_logs, "worker"))
+    if not os.path.isdir(pjoin(path_job_logs, "job")):
+        os.makedirs(pjoin(path_job_logs, "job"))
+
+    return path_job, path_job_logs, path_job_commands
 
 
 def log_command_line(path_job, command_line):

--- a/smartdispatch/tests/test_smartdispatch.py
+++ b/smartdispatch/tests/test_smartdispatch.py
@@ -146,6 +146,52 @@ def test_get_available_queues():
     assert_true(len(queues_infos) > 0)
 
 
+def test_get_job_folders():
+    temp_dir = tempfile.mkdtemp()
+    jobname = "this_is_the_name_of_my_job"
+    job_folders_paths = smartdispatch.get_job_folders(temp_dir, jobname)
+    path_job, path_job_logs, path_job_commands = job_folders_paths
+
+    assert_true(jobname in path_job)
+    assert_true(os.path.isdir(path_job))
+    assert_equal(os.path.basename(path_job), jobname)
+
+    assert_true(jobname in path_job_logs)
+    assert_true(os.path.isdir(path_job_logs))
+    assert_true(os.path.isdir(pjoin(path_job_logs, 'worker')))
+    assert_true(os.path.isdir(pjoin(path_job_logs, 'job')))
+    assert_true(os.path.isdir(path_job_logs))
+    assert_equal(os.path.basename(path_job_logs), "logs")
+
+    assert_true(jobname in path_job_commands)
+    assert_true(os.path.isdir(path_job_commands))
+    assert_equal(os.path.basename(path_job_commands), "commands")
+
+    # In theory the following should not create new folders.
+    # Insteead it will return the paths to existing folders.
+    jobname += "2"
+    os.rename(path_job, path_job + "2")
+    job_folders_paths = smartdispatch.get_job_folders(temp_dir, jobname)
+    path_job, path_job_logs, path_job_commands = job_folders_paths
+
+    assert_true(jobname in path_job)
+    assert_true(os.path.isdir(path_job))
+    assert_equal(os.path.basename(path_job), jobname)
+
+    assert_true(jobname in path_job_logs)
+    assert_true(os.path.isdir(path_job_logs))
+    assert_true(os.path.isdir(pjoin(path_job_logs, 'worker')))
+    assert_true(os.path.isdir(pjoin(path_job_logs, 'job')))
+    assert_true(os.path.isdir(path_job_logs))
+    assert_equal(os.path.basename(path_job_logs), "logs")
+
+    assert_true(jobname in path_job_commands)
+    assert_true(os.path.isdir(path_job_commands))
+    assert_equal(os.path.basename(path_job_commands), "commands")
+
+    shutil.rmtree(temp_dir)
+
+
 def test_log_command_line():
     temp_dir = tempfile.mkdtemp()
     command_line_log_file = pjoin(temp_dir, "command_line.log")


### PR DESCRIPTION
Currently we are force to provide the *Batch UID* when resume some jobs with `smart_dispatch`. This PR add also the option of providing the path (i.e. `SMART_DISPATCH_LOGS/{Batch UID}`).

Since I'm using the bash auto-complete to get the *Batch UID*, I find it frustrating to have to remove the `SMART_DISPATCH_LOGS/` part every time.