### PR TITLE
Save the command line in a file to keep an history

### DIFF
--- a/scripts/smart_dispatch.py
+++ b/scripts/smart_dispatch.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import re
 import os
+import sys
 import argparse
 import time as t
 import numpy as np
@@ -101,6 +103,14 @@ def main():
 
     job_generator = job_generator_factory(queue, commands, command_params, CLUSTER_NAME, path_job)
     pbs_filenames = job_generator.write_pbs_files(path_job_commands)
+
+    # Keep an history of command lines i.e. smart_dispatch.py commands.
+    with utils.open_with_lock(os.path.join(path_job, "command_line_history.txt"), 'a') as command_line_history_file:
+        command_line_history_file.write(t.strftime("## %Y-%m-%d %H:%M:%S ##\n"))
+        command_line = " ".join(sys.argv)
+        command_line = command_line.replace('"', r'\"')  # Make sure we can paste the command line as-is
+        command_line = re.sub(r'(\[)([^\[\]]*\\ [^\[\]]*)(\])', r'"\1\2\3"', command_line)  # Make sure we can paste the command line as-is
+        command_line_history_file.write(command_line + "\n\n")
 
     # Launch the jobs
     print "## {nb_commands} command(s) will be executed in {nb_jobs} job(s) ##".format(nb_commands=nb_commands, nb_jobs=len(pbs_filenames))

--- a/smartdispatch/smartdispatch.py
+++ b/smartdispatch/smartdispatch.py
@@ -4,6 +4,7 @@ import os
 import re
 import itertools
 import time as t
+from os.path import join as pjoin
 
 import smartdispatch
 from smartdispatch import utils
@@ -119,3 +120,23 @@ def get_available_queues(cluster_name=utils.detect_cluster()):
 
     queues_infos = utils.load_dict_from_json_file(config_filepath)
     return queues_infos
+
+
+def log_command_line(path_job, command_line):
+    """ Logs a command line in a job folder.
+
+    The command line is append to a file named 'command_line.log' that resides
+    in the given job folder. The current date and time is also added along
+    each command line logged.
+
+    Notes
+    -----
+    Commands save in log file might differ from sys.argv since we want to make sure
+    we can paste the command line as-is in the terminal. This means that the quotes
+    symbole " and the square brackets will be escaped.
+    """
+    with utils.open_with_lock(pjoin(path_job, "command_line.log"), 'a') as command_line_log:
+        command_line_log.write(t.strftime("## %Y-%m-%d %H:%M:%S ##\n"))
+        command_line = command_line.replace('"', r'\"')  # Make sure we can paste the command line as-is
+        command_line = re.sub(r'(\[)([^\[\]]*\\ [^\[\]]*)(\])', r'"\1\2\3"', command_line)  # Make sure we can paste the command line as-is
+        command_line_log.write(command_line + "\n\n")


### PR DESCRIPTION
It is often useful to check what was exactly the command I used to launch some experiments with `smart_dispatch`. This PR saves the command in a file in the job folder.