### PR TITLE
[FIX] use OrderedDict in PBS. [PEP8] replaced tabs with spaces.

### DIFF
--- a/smartdispatch/pbs.py
+++ b/smartdispatch/pbs.py
@@ -1,4 +1,5 @@
 import re
+from collections import OrderedDict
 
 regex_walltime = re.compile("(\d+:){1,4}")
 regex_resource_nodes = re.compile("[a-zA-Z0-9]+(:ppn=\d+)?(:gpus=\d+)?(:[a-zA-Z0-9]+)*")
@@ -26,10 +27,10 @@ class PBS(object):
         self.modules = []
         self.commands = []
 
-        self.resources = {}
+        self.resources = OrderedDict()
         self.add_resources(walltime=walltime)
 
-        self.options = {}
+        self.options = OrderedDict()
         self.add_options(q=queue_name)
 
         # Declares that all environment variables in the qsub command's environment are to be exported to the batch job.

--- a/smartdispatch/tests/test_pbs.py
+++ b/smartdispatch/tests/test_pbs.py
@@ -72,8 +72,8 @@ class TestPBS(unittest.TestCase):
     def test_str(self):
         # Create simple PBS file
         expected = """#!/bin/bash
-#PBS -V
 #PBS -q qtest@mp2
+#PBS -V
 #PBS -l walltime=01:00:00
 
 # Modules #
@@ -90,11 +90,11 @@ wait"""
         modules = ["CUDA_Toolkit/6.0", "python2.7"]
 
         expected = """#!/bin/bash
-#PBS -A xyz-123-ab
-#PBS -V
 #PBS -q qtest@mp2
-#PBS -l nodes=2:ppn=3:gpus=1
+#PBS -V
+#PBS -A xyz-123-ab
 #PBS -l walltime=01:00:00
+#PBS -l nodes=2:ppn=3:gpus=1
 
 # Modules #
 module load CUDA_Toolkit/6.0

--- a/tests/test_smart_dispatch.py
+++ b/tests/test_smart_dispatch.py
@@ -62,7 +62,6 @@ class TestSmartdispatcher(unittest.TestCase):
 
         # Test when batch_uid is a path instead of a jobname.
         # Setup
-        call(self.launch_command, shell=True)
         batch_uid = os.path.join(self.logs_dir, os.listdir(self.logs_dir)[0])
 
         # Simulate that some commands are in the running state.


### PR DESCRIPTION
Sometime the test in `test_pbs.py` were falling because we use `dict` to store options and resources. So writing the PBS file, we were iterating over the items of those dictionaries which is nondeterminist (depends on the hash of the keys). This PR fixes this by using OrderedDict instead.

Also, fixed some minor PEP8 errors. 