### PR TITLE
Provide mem_per_node argument when testing job_generator

### DIFF
--- a/smartdispatch/tests/test_job_generator.py
+++ b/smartdispatch/tests/test_job_generator.py
@@ -22,7 +22,7 @@ class TestJobGenerator(unittest.TestCase):
         self.mem_per_node = 32
         self.modules = ["cuda", "python"]
 
-        self.queue = Queue(self.name, self.cluster_name, self.walltime, self.cores, 0, self.modules)
+        self.queue = Queue(self.name, self.cluster_name, self.walltime, self.cores, 0, self.mem_per_node, self.modules)
         self.queue_gpu = Queue(self.name, self.cluster_name, self.walltime, self.cores, self.gpus, self.mem_per_node, self.modules)
 
     def tearDown(self):
@@ -56,6 +56,10 @@ class TestJobGenerator(unittest.TestCase):
 
         # Since queue has no gpus it should not be specified in PBS resource `nodes`
         assert_true('gpus' not in pbs_list[0].resources['nodes'])
+
+        # Test modules to load
+        # Check if needed modules for this queue are included in the PBS file
+        assert_equal(pbs_list[0].modules, self.modules)
 
         # Test nb_gpus_per_command argument
         # Should needs two PBS file


### PR DESCRIPTION
There was an error when testing job_generator. The argument `mem_per_node` of `Queue`'s constructor was missing. This resulted in the argument `modules` being `None` but since `modules` was not checked, no errors were raised.

This PR modifies the call to the `Queue`'s constructor in the test in order to provide correctly the `mem_per_node` argument. This PR also adds a test to check that `modules` parameter is set correctly.