### PR TITLE
Keep the history of 'smart-dispatch' commands that have been executed.

### DIFF
--- a/scripts/smart-dispatch
+++ b/scripts/smart-dispatch
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
+import re
 import os
 import sys
 import argparse
@@ -117,6 +118,14 @@ def main():
 
     job_generator = job_generator_factory(queue, commands, command_params, CLUSTER_NAME, path_job)
     pbs_filenames = job_generator.write_pbs_files(path_job_commands)
+
+    # Keep an history of 'smart-dispatch' commands executed.
+    with open_with_lock(pjoin(path_job, "history.txt"), 'a') as history_file:
+        history_file.write(t.strftime("## %Y-%m-%d %H:%M:%S ##\n"))
+        command_line = " ".join(sys.argv)
+        command_line = command_line.replace('"', r'\"')  # Make sure we can paste the command line as-is
+        command_line = re.sub(r'(\[)([^\[\]]*\\ [^\[\]]*)(\])', r'"\1\2\3"', command_line)  # Make sure we can paste the command line as-is
+        history_file.write(command_line + "\n\n")
 
     # Launch the jobs
     print "## {nb_commands} command(s) will be executed in {nb_jobs} job(s) ##".format(nb_commands=nb_commands, nb_jobs=len(pbs_filenames))


### PR DESCRIPTION
I find it useful to know what is the exact `smart-dispatch` command I've run. This PR adds that functionality by writing the command in a log file `SMART_DISPATCH_LOGS/{job_name}/history.txt`.