### PR TITLE
Small bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ python my_script.py 2 80 tanh 0.1
 ```
 
 Another possiblility is to generate argument from a range.
-``smart-dispatch -q qtest@mp2 launch python my_script.py [1:4]``
+
+`smart-dispatch -q qtest@mp2 launch python my_script.py [1:4]`
 
 Will generate:
 ```
@@ -54,7 +55,8 @@ python my_script.py 3
 ```
 
 You can also add a step size to the range as the 3rd argument.
-``smart-dispatch -q qtest@mp2 launch python my_script.py [1:10:2]``
+
+`smart-dispatch -q qtest@mp2 launch python my_script.py [1:10:2]`
 
 Will generate:
 ```

--- a/smartdispatch/smartdispatch.py
+++ b/smartdispatch/smartdispatch.py
@@ -105,7 +105,7 @@ def replace_uid_tag(commands):
     return [command.replace("{UID}", utils.generate_uid_from_string(command)) for command in commands]
 
 
-def get_available_queues(cluster_name=utils.detect_cluster()):
+def get_available_queues(cluster_name):
     """ Fetches all available queues on the current cluster """
     if cluster_name is None:
         return {}


### PR DESCRIPTION
First, there was 2 missing blank lines in the README.

Second, we were doing this:
```
get_available_queues(cluster_name=utils.detect_cluster()):
```

Which was calling `qstat` every time this function was imported.

And `smartdispatch/__init__.py` was importing it `from smartdispatch.smartdispatch import *`.

So `qstat` was called way too often for no reasons.
