### PR TITLE
Don't export the user's environment to the job

### DIFF
--- a/smartdispatch/pbs.py
+++ b/smartdispatch/pbs.py
@@ -36,7 +36,7 @@ class PBS(object):
         self.add_options(q=queue_name)
 
         # Declares that all environment variables in the qsub command's environment are to be exported to the batch job.
-        self.add_options(V="")
+        self.add_options(v="PBS_FILENAME")
 
     def add_options(self, **options):
         """ Adds options to this PBS file.


### PR DESCRIPTION
Fixes #157.

Currently the user's entire environment is exported. This is bad
practice because it makes jobs hard to reproduce and debug, and in some
cases it can even cause errors. The only variable that needs to be
exported is `PBS_FILENAME`, which is used by the auto-resume script.